### PR TITLE
Rudimentary apollo server and client implementation for the API

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,56 +1,26 @@
 import React from 'react'
-import { StyleSheet, Text, View, Image } from 'react-native'
-import { ButtonGroup, Button } from 'react-native-elements'
+import ApolloClient from 'apollo-client';
+import { HttpLink } from 'apollo-link-http';
+import { InMemoryCache } from 'apollo-cache-inmemory'
+import { ApolloProvider } from 'react-apollo';
+import Habits from './Habits'
 
 export default class App extends React.Component {
-  constructor () {
-    super()
-    this.state = {
-      selectedIndex: 2
-    }
-    this.updateIndex = this.updateIndex.bind(this)
-  }
+  constructor(...args) {
+    super(...args);
 
-  updateIndex (selectedIndex) {
-    this.setState({selectedIndex})
+    this.client = new ApolloClient({
+      link: new HttpLink({ uri: 'http://localhost:7700/graphql' }),
+      cache: new InMemoryCache().restore(window.__APOLLO_STATE__),
+    });
   }
 
   render () {
-    const { selectedIndex } = this.state
-    const component1 = () => <Button large backgroundColor="#00FF00" buttonStyle={ { width: '100%' } }/>
-    const component2 = () => <Text>World</Text>
-    const component3 = () => <Text>ButtonGroup</Text>
-    const buttons = [{ element: component1 }, { element: component2 }, { element: component3 }]
-  
     return (
-      <View style={styles.container}>
-        <Text>Life Tracking App</Text>
-        <ButtonGroup
-          onPress={this.updateIndex}
-          selectedIndex={selectedIndex}
-          buttons={buttons}
-          containerStyle={{height: 40}} />
-         <Image
-           style={{width: 150, height: 150}}
-           source={{uri: 'https://media.giphy.com/media/CO8wN7YrZ3X0Y/giphy.gif'}}
-         />
-         <Button
-           raised
-           icon={{name: 'home', size: 32}}
-           buttonStyle={{backgroundColor: 'red', borderRadius: 10}}
-           textStyle={{textAlign: 'center'}}
-           title={`Welcome to\nReact Native Elements`}
-         />
-      </View>
+      <ApolloProvider client={this.client}>
+        <Habits/>
+      </ApolloProvider>
     )
   }
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/mobile/Habit.js
+++ b/mobile/Habit.js
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { StyleSheet, Text, View, Image } from 'react-native'
+import { Button, ButtonGroup } from 'react-native-elements'; // 0.16.0
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+})
+
+const thisWeek = () => {
+  var curr = new Date; // get current date
+  var first = curr.getDate() - curr.getDay(); // First day is the day of the month - the day of the week
+  var last = first + 6; // last day is the first day + 6
+
+  var firstday = new Date(curr.setDate(first))
+  var lastday = new Date(curr.setDate(last))
+
+}
+
+const habitRow = (name, records) => {
+  const buttons = records.map(record => {
+    const {didAction, date} = record
+    const bgColor = didAction ? "#00FF00":"#FF0000"
+    return {element: () => <Button backgroundColor={bgColor}></Button>}
+  })  
+  return (
+    <View>
+      <Text style={styles.header}>{name}</Text>
+      <ButtonGroup 
+        buttons={buttons}
+        containerStyle={{height: 10, width: 200}}
+        onPress={() => {}}
+        selectedIndex={0} />     
+    </View>
+  )
+}
+
+
+export default class Habit extends React.Component {
+  render() {
+    const {id, name, records} = this.props
+    return (
+      <View key={id} style={styles.wrapper}>
+          {habitRow(name, records)}
+      </View>
+    )
+  }
+}
+
+Habit.propTypes = {
+    id: PropTypes.string,
+    name: PropTypes.string,
+    records: PropTypes.arrayOf(PropTypes.shape({
+      didAction: PropTypes.bool,
+      date: PropTypes.string
+    }))
+}

--- a/mobile/Habits.js
+++ b/mobile/Habits.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import { StyleSheet, Text, View, Image } from 'react-native'
+import gql from 'graphql-tag';
+import { graphql } from 'react-apollo';
+
+// The data prop, which is provided by the wrapper below contains,
+// a `loading` key while the query is in flight and posts when ready
+function Habits({ data: { loading, habits } }) {
+  if (loading) {
+    return <Text style={styles.outer}>Loading</Text>;
+  } else {
+    return (
+      <View style={styles.container}>
+        <Text>Habits: The Life Hacking App</Text>
+        {habits.map(habit => (
+          <View key={habit.id} style={styles.wrapper}>
+            <View>
+              <Text style={styles.header}>{habit.name}</Text>
+            </View>
+         </View>
+        ))}
+      </View>
+    )
+  }
+}      
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+})
+
+// The `graphql` wrapper executes a GraphQL query and makes the results
+// available on the `data` prop of the wrapped component (Habits here)
+export default graphql(gql`
+  query allHabits {
+    habits {
+      id
+      name
+      records {
+        didAction
+        date
+      }
+    }
+  }
+`)(Habits);

--- a/mobile/Habits.js
+++ b/mobile/Habits.js
@@ -2,9 +2,10 @@ import React from 'react'
 import { StyleSheet, Text, View, Image } from 'react-native'
 import gql from 'graphql-tag';
 import { graphql } from 'react-apollo';
+import Habit from './Habit'
 
 // The data prop, which is provided by the wrapper below contains,
-// a `loading` key while the query is in flight and posts when ready
+// a `loading` key while the query is in flight and habits when ready
 function Habits({ data: { loading, habits } }) {
   if (loading) {
     return <Text style={styles.outer}>Loading</Text>;
@@ -13,11 +14,7 @@ function Habits({ data: { loading, habits } }) {
       <View style={styles.container}>
         <Text>Habits: The Life Hacking App</Text>
         {habits.map(habit => (
-          <View key={habit.id} style={styles.wrapper}>
-            <View>
-              <Text style={styles.header}>{habit.name}</Text>
-            </View>
-         </View>
+          <Habit key={habit.id} {...habit}/>
         ))}
       </View>
     )

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,8 +19,14 @@
     "preset": "jest-expo"
   },
   "dependencies": {
+    "apollo-cache-inmemory": "^1.1.5",
+    "apollo-client": "^2.2.0",
+    "apollo-link-http": "^1.3.2",
     "expo": "^23.0.4",
+    "graphql": "^0.12.3",
+    "graphql-tag": "^2.6.1",
     "react": "16.0.0",
+    "react-apollo": "^2.0.4",
     "react-native": "0.50.3",
     "react-native-elements": "^0.18.5"
   }

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -60,6 +60,14 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
+"@types/async@2.0.46":
+  version "2.0.46"
+  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.46.tgz#f13a6c336a6582b95d0c0269e796b709488fd54d"
+
+"@types/zen-observable@0.5.3", "@types/zen-observable@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
+
 Base64@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.1.4.tgz#e9f6c6bef567fd635ea4162ab14dd329e74aa6de"
@@ -205,6 +213,58 @@ anymatch@^1.3.0:
   dependencies:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
+
+apollo-cache-inmemory@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.5.tgz#74111367fd59caee120197ef663dcb2516971300"
+  dependencies:
+    apollo-cache "^1.1.0"
+    apollo-utilities "^1.0.4"
+    graphql-anywhere "^4.1.1"
+
+apollo-cache@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.0.tgz#281b6a0fb6ca2c5bce69825642f685de92d05f3c"
+  dependencies:
+    apollo-utilities "^1.0.4"
+
+apollo-client@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.2.0.tgz#e22c4ba3a3c01aec6dc916a5dbc0f39c58d277fb"
+  dependencies:
+    "@types/zen-observable" "^0.5.3"
+    apollo-cache "^1.1.0"
+    apollo-link "^1.0.0"
+    apollo-link-dedup "^1.0.0"
+    apollo-utilities "^1.0.4"
+    symbol-observable "^1.0.2"
+    zen-observable "^0.7.0"
+  optionalDependencies:
+    "@types/async" "2.0.46"
+
+apollo-link-dedup@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.5.tgz#1c213d7ebbe48e74b016fffacd7e6a53dc309e32"
+  dependencies:
+    apollo-link "^1.0.7"
+
+apollo-link-http@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.3.2.tgz#63537ee5ecf9c004efb0317f1222b7dbc6f21559"
+  dependencies:
+    apollo-link "^1.0.7"
+
+apollo-link@^1.0.0, apollo-link@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.0.7.tgz#42cd38a7378332fc3e41a214ff6a6e5e703a556f"
+  dependencies:
+    "@types/zen-observable" "0.5.3"
+    apollo-utilities "^1.0.0"
+    zen-observable "^0.6.0"
+
+apollo-utilities@^1.0.0, apollo-utilities@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.4.tgz#560009ea5541b9fdc4ee07ebb1714ee319a76c15"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -852,21 +912,13 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@6.23.0:
+babel-polyfill@6.23.0, babel-polyfill@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
   dependencies:
     babel-runtime "^6.22.0"
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
-
-babel-polyfill@^6.23.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    regenerator-runtime "^0.10.5"
 
 babel-preset-es2015-node@^6.1.1:
   version "6.1.1"
@@ -2435,6 +2487,22 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graphql-anywhere@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.1.tgz#67924b67b053d1a23bc30d0e4c8db943c1d791a8"
+  dependencies:
+    apollo-utilities "^1.0.4"
+
+graphql-tag@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.6.1.tgz#4788d509f6e29607d947fc47a40c4e18f736d34a"
+
+graphql@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
+  dependencies:
+    iterall "1.1.3"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -2566,7 +2634,7 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^2.2.1:
+hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
@@ -2639,7 +2707,7 @@ https-proxy-agent@1, https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
-iconv-lite@0.4.11:
+iconv-lite@0.4.11, iconv-lite@^0.4.8:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
 
@@ -2647,7 +2715,7 @@ iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@^0.4.8, iconv-lite@~0.4.13:
+iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -2731,7 +2799,7 @@ instapromise@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/instapromise/-/instapromise-2.0.7.tgz#85e66b31021194da11214c865127ef04ec30167a"
 
-invariant@^2.0.0, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -2990,6 +3058,10 @@ istanbul-reports@^1.1.3:
 items@2.x.x:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/items/-/items-2.1.1.tgz#8bd16d9c83b19529de5aea321acaada78364a198"
+
+iterall@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
 jest-changed-files@^21.2.0:
   version "21.2.0"
@@ -3511,6 +3583,10 @@ lodash.escape@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
+lodash.flowright@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flowright/-/lodash.flowright-3.5.0.tgz#2b5fff399716d7e7dc5724fe9349f67065184d67"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3550,6 +3626,10 @@ lodash.padend@^4.1.0:
 lodash.padstart@^4.1.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
 
 lodash.restparam@^3.0.0:
   version "3.6.1"
@@ -3794,13 +3874,13 @@ mime-db@~1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.23.0.tgz#a31b4070adaea27d732ea333740a64d0ec9a6659"
 
-mime-types@2.1.11:
+mime-types@2.1.11, mime-types@~2.1.9:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.11.tgz#c259c471bda808a85d6cd193b430a5fae4473b3c"
   dependencies:
     mime-db "~1.23.0"
 
-mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.6, mime-types@~2.1.7, mime-types@~2.1.9:
+mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.6, mime-types@~2.1.7:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
@@ -3888,13 +3968,9 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-ms@2.0.0:
+ms@2.0.0, ms@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-
-ms@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
 multiparty@3.3.2:
   version "3.3.2"
@@ -4569,6 +4645,17 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-apollo@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.0.4.tgz#01dd32a8e388672f5d7385b21cdd0b94009ee9ee"
+  dependencies:
+    apollo-link "^1.0.0"
+    hoist-non-react-statics "^2.2.0"
+    invariant "^2.2.1"
+    lodash.flowright "^3.5.0"
+    lodash.pick "^4.4.0"
+    prop-types "^15.5.8"
+
 react-clone-referenced-element@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz#2bba8c69404c5e4a944398600bcc4c941f860682"
@@ -4827,7 +4914,7 @@ regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
 
-regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
+regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
@@ -5500,7 +5587,7 @@ swap-case@^1.1.0:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
 
-symbol-observable@^1.0.3:
+symbol-observable@^1.0.2, symbol-observable@^1.0.3:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
 
@@ -5804,7 +5891,7 @@ uuid@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
-uuid@3.0.1:
+uuid@3.0.1, uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
@@ -5812,7 +5899,7 @@ uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
@@ -5892,11 +5979,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.19"
 
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-
-whatwg-fetch@^1.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 
@@ -6181,3 +6264,11 @@ yargs@~3.10.0:
 yesno@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/yesno/-/yesno-0.0.1.tgz#ffbc04ff3d6f99dad24f7463134e9b92ae41bef6"
+
+zen-observable@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.6.1.tgz#01dbed3bc8d02cbe9ee1112c83e04c807f647244"
+
+zen-observable@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.7.1.tgz#f84075c0ee085594d3566e1d6454207f126411b3"

--- a/server/index.js
+++ b/server/index.js
@@ -1,25 +1,25 @@
-import express from 'express';
-import cors from 'cors';
+import express from 'express'
+import cors from 'cors'
 import {
   graphqlExpress,
   graphiqlExpress,
-} from 'graphql-server-express';
-import bodyParser from 'body-parser';
+} from 'graphql-server-express'
+import bodyParser from 'body-parser'
 
-import { schema } from './src/schema';
+import { schema } from './src/schema'
 
-const PORT = 7700;
-const server = express();
-server.use('*', cors({ origin: 'http://localhost:8000' })); //Restrict the client-origin for security reasons.
+const PORT = 7700
+const server = express()
+server.use('*', cors({ origin: 'http://localhost:8000' })) //Restrict the client-origin for security reasons.
 
 server.use('/graphql', bodyParser.json(), graphqlExpress({
   schema 
-}));
+}))
 
 server.use('/graphiql', graphiqlExpress({
   endpointURL: '/graphql'
-}));
+}))
 
 server.listen(PORT, () =>
   console.log(`GraphQL Server is now running on http://localhost:${PORT}`)
-);
+)

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,47 @@
-const express = require('express')
-const app = express()
-const port = process.env.PORT || 3000
+const express = require('express');
+const bodyParser = require('body-parser');
+const { graphqlExpress, graphiqlExpress } = require('apollo-server-express');
+const { makeExecutableSchema } = require('graphql-tools');
 
-app.get('')
+// Some fake data
+const books = [
+  {
+    title: "Harry Potter and the Sorcerer's stone",
+    author: 'J.K. Rowling',
+  },
+  {
+    title: 'Jurassic Park',
+    author: 'Michael Crichton',
+  },
+];
 
-app.listen(port)
+// The GraphQL schema in string form
+const typeDefs = `
+  type Query { books: [Book] }
+  type Book { title: String, author: String }
+`;
+
+// The resolvers
+const resolvers = {
+  Query: { books: () => books },
+};
+
+// Put together a schema
+const schema = makeExecutableSchema({
+  typeDefs,
+  resolvers,
+});
+
+// Initialize the app
+const app = express();
+
+// The GraphQL endpoint
+app.use('/graphql', bodyParser.json(), graphqlExpress({ schema }));
+
+// GraphiQL, a visual editor for queries
+app.use('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }));
+
+// Start the server
+app.listen(3000, () => {
+  console.log('Go to http://localhost:3000/graphiql to run queries!');
+});

--- a/server/index.js
+++ b/server/index.js
@@ -1,47 +1,25 @@
-const express = require('express');
-const bodyParser = require('body-parser');
-const { graphqlExpress, graphiqlExpress } = require('apollo-server-express');
-const { makeExecutableSchema } = require('graphql-tools');
+import express from 'express';
+import cors from 'cors';
+import {
+  graphqlExpress,
+  graphiqlExpress,
+} from 'graphql-server-express';
+import bodyParser from 'body-parser';
 
-// Some fake data
-const books = [
-  {
-    title: "Harry Potter and the Sorcerer's stone",
-    author: 'J.K. Rowling',
-  },
-  {
-    title: 'Jurassic Park',
-    author: 'Michael Crichton',
-  },
-];
+import { schema } from './src/schema';
 
-// The GraphQL schema in string form
-const typeDefs = `
-  type Query { books: [Book] }
-  type Book { title: String, author: String }
-`;
+const PORT = 7700;
+const server = express();
+server.use('*', cors({ origin: 'http://localhost:8000' })); //Restrict the client-origin for security reasons.
 
-// The resolvers
-const resolvers = {
-  Query: { books: () => books },
-};
+server.use('/graphql', bodyParser.json(), graphqlExpress({
+  schema 
+}));
 
-// Put together a schema
-const schema = makeExecutableSchema({
-  typeDefs,
-  resolvers,
-});
+server.use('/graphiql', graphiqlExpress({
+  endpointURL: '/graphql'
+}));
 
-// Initialize the app
-const app = express();
-
-// The GraphQL endpoint
-app.use('/graphql', bodyParser.json(), graphqlExpress({ schema }));
-
-// GraphiQL, a visual editor for queries
-app.use('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }));
-
-// Start the server
-app.listen(3000, () => {
-  console.log('Go to http://localhost:3000/graphiql to run queries!');
-});
+server.listen(PORT, () =>
+  console.log(`GraphQL Server is now running on http://localhost:${PORT}`)
+);

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/deadlyicon/life-tracking-app#readme",
   "dependencies": {
+    "apollo-server-express": "^1.3.2",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "graphql": "^0.12.3",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,9 @@
   "description": "life tracking app server",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "build": "babel src -d lib",
+    "start": "nodemon index.js --exec babel-node --presets es2015 stage-2"
   },
   "repository": "git+https://github.com/deadlyicon/life-tracking-app.git",
   "author": "",
@@ -15,12 +17,18 @@
   "homepage": "https://github.com/deadlyicon/life-tracking-app#readme",
   "dependencies": {
     "apollo-server-express": "^1.3.2",
+    "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-2": "^6.24.1",
     "body-parser": "^1.18.2",
+    "cors": "^2.8.4",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "graphql": "^0.12.3",
+    "graphql-server-express": "^1.3.2",
     "graphql-tools": "^2.18.0",
     "knex": "^0.14.2",
+    "nodemon": "^1.14.11",
     "pg": "^7.4.1"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "graphql-server-express": "^1.3.2",
     "graphql-tools": "^2.18.0",
     "knex": "^0.14.2",
+    "moment": "^2.20.1",
     "nodemon": "^1.14.11",
     "pg": "^7.4.1"
   }

--- a/server/package.json
+++ b/server/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "test": "mocha"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/deadlyicon/life-tracking-app.git"
-  },
+  "repository": "git+https://github.com/deadlyicon/life-tracking-app.git",
   "author": "",
   "license": "MIT",
   "bugs": {
@@ -18,9 +15,11 @@
   "homepage": "https://github.com/deadlyicon/life-tracking-app#readme",
   "dependencies": {
     "apollo-server-express": "^1.3.2",
+    "body-parser": "^1.18.2",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "graphql": "^0.12.3",
+    "graphql-tools": "^2.18.0",
     "knex": "^0.14.2",
     "pg": "^7.4.1"
   }

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha",
     "build": "babel src -d lib",
-    "start": "nodemon index.js --exec babel-node --presets es2015 stage-2"
+    "start": "nodemon index.js --exec babel-node --presets es2015 stage-2",
+    "lint": "./node_modules/.bin/eslint **/*.js"
   },
   "repository": "git+https://github.com/deadlyicon/life-tracking-app.git",
   "author": "",
@@ -23,6 +24,7 @@
     "body-parser": "^1.18.2",
     "cors": "^2.8.4",
     "dotenv": "^4.0.0",
+    "eslint": "^4.16.0",
     "express": "^4.16.2",
     "graphql": "^0.12.3",
     "graphql-server-express": "^1.3.2",

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -1,5 +1,6 @@
 import { GraphQLScalarType } from 'graphql';
 import { Kind } from 'graphql/language';
+import moment from 'moment';
 // app/src/resolvers.js
 const habits = [{
   id: 1,
@@ -17,21 +18,20 @@ const getHabit = (id) => {
   return habits.find(habit => habit.id == id)
 }
 
+const DATE_FORMAT = 'YYYYMMDD'
+
 export const resolvers = {
   Date: new GraphQLScalarType({
     name: 'Date',
     description: 'Date custom scalar type',
     parseValue(value) {
-      return new Date(value); // value from the client
+      return new moment(value, DATE_FORMAT)
     },
     serialize(value) {
       return value;
     },
     parseLiteral(ast) {
-      if (ast.kind === Kind.INT) {
-        return parseInt(ast.value, 10); // ast value is always in string format
-      }
-      return null;
+      return new moment(ast.value, DATE_FORMAT).format(DATE_FORMAT); //This should protect against bad data
     },
   }),
   Query: {

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -1,0 +1,28 @@
+// app/src/resolvers.js
+const channels = [{
+  id: 1,
+  name: 'soccer',
+}, {
+  id: 2,
+  name: 'baseball',
+}];
+
+let nextId = 3;
+
+export const resolvers = {
+  Query: {
+    channels: () => {
+      return channels;
+    },
+    channel: (root, { id }) => {
+      return channels.find(channel => channel.id == id);
+    },
+  },
+  Mutation: {
+    addChannel: (root, args) => {
+      const newChannel = { id: nextId++, name: args.name };
+      channels.push(newChannel);
+      return newChannel;
+    },
+  },
+};

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -59,5 +59,12 @@ export const resolvers = {
       }
       return habit
     },
+
+    deleteAction: (root, { input }) => {
+      const { habitId, date } = input
+      const habit = getHabit(habitId)
+      habit.records = habit.records.filter(record => record.date != date)
+      return habit
+    }
   },
 };

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -1,8 +1,7 @@
-import { GraphQLScalarType } from 'graphql';
-import { Kind } from 'graphql/language';
-import moment from 'moment';
+import { GraphQLScalarType } from 'graphql'
+import moment from 'moment'
 import sortBy from 'lodash/sortBy'
-// app/src/resolvers.js
+
 const habits = [{
   id: 1,
   name: 'exercise',
@@ -13,7 +12,7 @@ const habits = [{
   records: []
 }]
 
-let nextId = 3;
+let nextId = 3
 
 const getHabit = (id) => {
   return habits.find(habit => habit.id == id)
@@ -23,7 +22,7 @@ const DATE_FORMAT = 'YYYYMMDD'
 
 export const resolvers = {
   Habit: {
-    records(obj, args, context) {
+    records(obj) {
       return sortBy(obj.records, (record => record.date))
     }
   },
@@ -34,15 +33,15 @@ export const resolvers = {
       return new moment(value, DATE_FORMAT)
     },
     serialize(value) {
-      return value;
+      return value
     },
     parseLiteral(ast) {
-      return new moment(ast.value, DATE_FORMAT).format(DATE_FORMAT); //This should protect against bad data
+      return new moment(ast.value, DATE_FORMAT).format(DATE_FORMAT) //This should protect against bad data
     },
   }),
   Query: {
     habits: () => {
-      return habits;
+      return habits
     },
     habit: (root, { id }) => {
       getHabit(id)
@@ -50,9 +49,9 @@ export const resolvers = {
   },
   Mutation: {
     addHabit: (root, args) => {
-      const newHabit = { id: nextId++, name: args.name };
-      habits.push(newHabit);
-      return newHabit;
+      const newHabit = { id: nextId++, name: args.name }
+      habits.push(newHabit)
+      return newHabit
     },
     recordAction: (root, { input }) => {
       const { habitId, date, didAction } = input
@@ -73,4 +72,4 @@ export const resolvers = {
       return habit
     }
   },
-};
+}

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -1,22 +1,45 @@
+import { GraphQLScalarType } from 'graphql';
+import { Kind } from 'graphql/language';
 // app/src/resolvers.js
 const habits = [{
   id: 1,
   name: 'exercise',
+  records: []
 }, {
   id: 2,
-  name: 'brush teeth'
-
+  name: 'brush teeth',
+  records: []
 }]
 
 let nextId = 3;
 
+const getHabit = (id) => {
+  return habits.find(habit => habit.id == id)
+}
+
 export const resolvers = {
+  Date: new GraphQLScalarType({
+    name: 'Date',
+    description: 'Date custom scalar type',
+    parseValue(value) {
+      return new Date(value); // value from the client
+    },
+    serialize(value) {
+      return value;
+    },
+    parseLiteral(ast) {
+      if (ast.kind === Kind.INT) {
+        return parseInt(ast.value, 10); // ast value is always in string format
+      }
+      return null;
+    },
+  }),
   Query: {
     habits: () => {
       return habits;
     },
     habit: (root, { id }) => {
-      return habits.find(habit => habit.id == id);
+      getHabit(id)
     }
   },
   Mutation: {
@@ -24,6 +47,17 @@ export const resolvers = {
       const newHabit = { id: nextId++, name: args.name };
       habits.push(newHabit);
       return newHabit;
+    },
+    recordAction: (root, { input }) => {
+      const { habitId, date, didAction } = input
+      const habit = getHabit(habitId)
+      const existingRecord =  habit.records.find(record => record.date == date)
+      if (existingRecord) {
+        existingRecord.didAction = didAction
+      } else {
+        habit.records.push({ date, didAction })
+      }
+      return habit
     },
   },
 };

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -1,28 +1,29 @@
 // app/src/resolvers.js
-const channels = [{
+const habits = [{
   id: 1,
-  name: 'soccer',
+  name: 'exercise',
 }, {
   id: 2,
-  name: 'baseball',
-}];
+  name: 'brush teeth'
+
+}]
 
 let nextId = 3;
 
 export const resolvers = {
   Query: {
-    channels: () => {
-      return channels;
+    habits: () => {
+      return habits;
     },
-    channel: (root, { id }) => {
-      return channels.find(channel => channel.id == id);
-    },
+    habit: (root, { id }) => {
+      return habits.find(habit => habit.id == id);
+    }
   },
   Mutation: {
-    addChannel: (root, args) => {
-      const newChannel = { id: nextId++, name: args.name };
-      channels.push(newChannel);
-      return newChannel;
+    addHabit: (root, args) => {
+      const newHabit = { id: nextId++, name: args.name };
+      habits.push(newHabit);
+      return newHabit;
     },
   },
 };

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -1,6 +1,7 @@
 import { GraphQLScalarType } from 'graphql';
 import { Kind } from 'graphql/language';
 import moment from 'moment';
+import sortBy from 'lodash/sortBy'
 // app/src/resolvers.js
 const habits = [{
   id: 1,
@@ -21,6 +22,11 @@ const getHabit = (id) => {
 const DATE_FORMAT = 'YYYYMMDD'
 
 export const resolvers = {
+  Habit: {
+    records(obj, args, context) {
+      return sortBy(obj.records, (record => record.date))
+    }
+  },
   Date: new GraphQLScalarType({
     name: 'Date',
     description: 'Date custom scalar type',

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -1,7 +1,7 @@
 // app/src/schema.js
-import {  makeExecutableSchema } from 'graphql-tools';
+import {  makeExecutableSchema } from 'graphql-tools'
 
-import { resolvers } from './resolvers'; // Will be implemented at a later stage.
+import { resolvers } from './resolvers' // Will be implemented at a later stage.
 
 const typeDefs = `
     scalar Date
@@ -42,7 +42,7 @@ const typeDefs = `
       habitId: ID!
       date: Date!
     }
-    `;
+    `
 
-const schema = makeExecutableSchema({ typeDefs, resolvers });
-export { schema };
+const schema = makeExecutableSchema({ typeDefs, resolvers })
+export { schema }

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -4,10 +4,17 @@ import {  makeExecutableSchema } from 'graphql-tools';
 import { resolvers } from './resolvers'; // Will be implemented at a later stage.
 
 const typeDefs = `
+    scalar Date
+
     type Habit {
       id: ID!
       name: String
+      records: [Record]
+    }
 
+    type Record {
+      date: Date
+      didAction: Boolean 
     }
 
 
@@ -21,6 +28,13 @@ const typeDefs = `
     type Mutation {
       # A mutation to add a new habit to the list of habits
       addHabit(name: String!): Habit
+      recordAction(input: RecordActionInput!): Habit
+    }
+
+    input RecordActionInput {
+      habitId: ID!
+      date: Date!
+      didAction: Boolean!
     }
     `;
 

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -29,12 +29,18 @@ const typeDefs = `
       # A mutation to add a new habit to the list of habits
       addHabit(name: String!): Habit
       recordAction(input: RecordActionInput!): Habit
+      deleteAction(input: DeleteActionInput!): Habit
     }
 
     input RecordActionInput {
       habitId: ID!
       date: Date!
       didAction: Boolean!
+    }
+
+    input DeleteActionInput {
+      habitId: ID!
+      date: Date!
     }
     `;
 

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -4,26 +4,23 @@ import {  makeExecutableSchema } from 'graphql-tools';
 import { resolvers } from './resolvers'; // Will be implemented at a later stage.
 
 const typeDefs = `
-    type Channel {
-      id: ID!                # "!" denotes a required field
+    type Habit {
+      id: ID!
       name: String
-      messages: [Message]!
+
     }
 
-    type Message {
-      id: ID!
-      text: String
-    }
+
     # This type specifies the entry points into our API. 
     type Query {
-      channels: [Channel]    # "[]" means this is a list of channels
-      channel(id: ID!): Channel
+      habits: [Habit] #List of habits
+      habit(id: ID!): Habit
     }
 
     # The mutation root type, used to define all mutations.
     type Mutation {
-      # A mutation to add a new channel to the list of channels
-      addChannel(name: String!): Channel
+      # A mutation to add a new habit to the list of habits
+      addHabit(name: String!): Habit
     }
     `;
 

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -1,0 +1,31 @@
+// app/src/schema.js
+import {  makeExecutableSchema } from 'graphql-tools';
+
+import { resolvers } from './resolvers'; // Will be implemented at a later stage.
+
+const typeDefs = `
+    type Channel {
+      id: ID!                # "!" denotes a required field
+      name: String
+      messages: [Message]!
+    }
+
+    type Message {
+      id: ID!
+      text: String
+    }
+    # This type specifies the entry points into our API. 
+    type Query {
+      channels: [Channel]    # "[]" means this is a list of channels
+      channel(id: ID!): Channel
+    }
+
+    # The mutation root type, used to define all mutations.
+    type Mutation {
+      # A mutation to add a new channel to the list of channels
+      addChannel(name: String!): Channel
+    }
+    `;
+
+const schema = makeExecutableSchema({ typeDefs, resolvers });
+export { schema };


### PR DESCRIPTION
This is just an initial implementation (in-memory storage),and in-memory cache in the client.


Should show:
![image](https://user-images.githubusercontent.com/1440689/35534235-b7667ff2-04f4-11e8-9e5d-e497db46e57a.png)



To run:
`cd server ; yarn ; yarn start`
and in another term:
`cd mobile ; yarn ; yarn start`

I've added the following graphql queries and mutations:

```
mutations:
      habits: [Habit] #List of habits
      habit(id: ID!): Habit
queries:
      addHabit(name: String!): Habit
      recordAction(input: RecordActionInput!): Habit
      deleteAction(input: DeleteActionInput!): Habit
```

To run one of them, yarn, yarn start, then hit:

`localhost:7700/graphiql` in a browser.

From there, you can paste in these to check it out:

```
query {
  habits {
    id
    name
    records {
      date
      didAction
    }
  }
}

mutation {
  recordAction(input:{
    habitId: "1", date: "20180124", didAction: true
  } ) {
    id
    name
    records {
      didAction
      date
    }
  }
}

mutation {
  deleteAction(input:{
    habitId: "1", date: "20180124"
  } ) {
    id
    records {
      didAction
      date
    }
  }
}
```